### PR TITLE
Clean buffer to avoid reallocation

### DIFF
--- a/src/elastic_push.rs
+++ b/src/elastic_push.rs
@@ -76,7 +76,7 @@ pub async fn consumer_loop(rx: &mut mpsc::UnboundedReceiver<LogMsg>, config: Ela
             response.is_ok(),
             response
         );
-        buffer = Vec::with_capacity(config.chunk_size.into());
+        buffer.clear();
     }
     println!("Producer dropped, consumer exiting");
 }


### PR DESCRIPTION
This might be not performance critical tool, but I think this could help a bit. 